### PR TITLE
Improve environment detection

### DIFF
--- a/codex-cli/src/utils/agent/agent-loop.ts
+++ b/codex-cli/src/utils/agent/agent-loop.ts
@@ -33,6 +33,7 @@ import { applyPatchToolInstructions } from "./apply-patch.js";
 import { handleExecCommand } from "./handle-exec-command.js";
 import { HttpsProxyAgent } from "https-proxy-agent";
 import { spawnSync } from "node:child_process";
+import { getEnvironmentInfo } from "../platform-info.js";
 import { randomUUID } from "node:crypto";
 import OpenAI, { APIConnectionTimeoutError, AzureOpenAI } from "openai";
 import os from "os";
@@ -1599,9 +1600,12 @@ export class AgentLoop {
 // Dynamic developer message prefix: includes user, workdir, and rg suggestion.
 const userName = os.userInfo().username;
 const workdir = process.cwd();
+const { platform, shell } = getEnvironmentInfo();
 const dynamicLines: Array<string> = [
   `User: ${userName}`,
   `Workdir: ${workdir}`,
+  `Platform: ${platform}`,
+  `Shell: ${shell}`,
 ];
 if (spawnSync("rg", ["--version"], { stdio: "ignore" }).status === 0) {
   dynamicLines.push(

--- a/codex-cli/src/utils/platform-info.ts
+++ b/codex-cli/src/utils/platform-info.ts
@@ -1,0 +1,9 @@
+import os from "os";
+import path from "path";
+
+export function getEnvironmentInfo(): { platform: string; shell: string } {
+  const platform = `${os.platform()} ${os.arch()} ${os.release()}`;
+  const shellPath = process.env["SHELL"] || process.env["ComSpec"] || "";
+  const shell = shellPath ? path.basename(shellPath) : "unknown";
+  return { platform, shell };
+}

--- a/codex-cli/tests/environment-info.test.ts
+++ b/codex-cli/tests/environment-info.test.ts
@@ -1,0 +1,13 @@
+import { getEnvironmentInfo } from "../src/utils/platform-info.js";
+import { test, expect } from "vitest";
+import os from "os";
+import path from "path";
+
+test("reports platform and shell", () => {
+  const info = getEnvironmentInfo();
+  const expectedPlatform = `${os.platform()} ${os.arch()} ${os.release()}`;
+  const shellPath = process.env["SHELL"] || process.env["ComSpec"] || "";
+  const expectedShell = shellPath ? path.basename(shellPath) : "unknown";
+  expect(info.platform).toBe(expectedPlatform);
+  expect(info.shell).toBe(expectedShell);
+});


### PR DESCRIPTION
## Summary
- add cross-platform environment detection helper
- include platform and shell info in agent prefix
- add unit test for environment info

## Testing
- `pnpm exec tsc -p codex-cli/tsconfig.json --noEmit`
- `pnpm --filter ./codex-cli test tests/environment-info.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68521c7d05e0832fbc0d06e4b7ee0476