### PR TITLE
Add max_context_length config override

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,12 +363,16 @@ Codex configuration files can be placed in the `~/.codex/` directory, supporting
 
 ### Basic configuration parameters
 
-| Parameter           | Type    | Default    | Description                      | Available Options                                                                              |
-| ------------------- | ------- | ---------- | -------------------------------- | ---------------------------------------------------------------------------------------------- |
-| `model`             | string  | `o4-mini`  | AI model to use                  | Any model name supporting OpenAI API                                                           |
-| `approvalMode`      | string  | `suggest`  | AI assistant's permission mode   | `suggest` (suggestions only)<br>`auto-edit` (automatic edits)<br>`full-auto` (fully automatic) |
-| `fullAutoErrorMode` | string  | `ask-user` | Error handling in full-auto mode | `ask-user` (prompt for user input)<br>`ignore-and-continue` (ignore and proceed)               |
-| `notify`            | boolean | `true`     | Enable desktop notifications     | `true`/`false`                                                                                 |
+| Parameter           | Type    | Default    | Description                              | Available Options                                                                              |
+| ------------------- | ------- | ---------- | ---------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| `model`             | string  | `o4-mini`  | AI model to use                          | Any model name supporting OpenAI API                                                           |
+| `approvalMode`      | string  | `suggest`  | AI assistant's permission mode           | `suggest` (suggestions only)<br>`auto-edit` (automatic edits)<br>`full-auto` (fully automatic) |
+| `fullAutoErrorMode` | string  | `ask-user` | Error handling in full-auto mode         | `ask-user` (prompt for user input)<br>`ignore-and-continue` (ignore and proceed)               |
+| `notify`            | boolean | `true`     | Enable desktop notifications             | `true`/`false`                                                                                 |
+| `maxContextLength`  | number  | _none_     | Override maximum context length (tokens) |
+| Any positive number |
+
+Use `maxContextLength` if you want to override the built-in token limits for your chosen model. This is useful when working with fine-tuned models that support different context sizes.
 
 ### Custom AI provider configuration
 
@@ -420,6 +424,7 @@ Below is a comprehensive example of `config.json` with multiple custom providers
 {
   "model": "o4-mini",
   "provider": "openai",
+  "max_context_length": 16000,
   "providers": {
     "openai": {
       "name": "OpenAI",

--- a/README.md
+++ b/README.md
@@ -308,14 +308,13 @@ Below are a few bite-size examples you can copy-paste. Replace the text in quote
 
 ---
 
-## Installation
-
-<details open>
-<summary><strong>From npm (Recommended)</strong></summary>
-
-```bash
-npm install -g @openai/codex
-# or
+| Parameter           | Type    | Default    | Description | Available Options |
+| ------------------- | ------- | ---------- | ----------- | ----------------- |
+| `model`             | string  | `o4-mini`  | AI model to use | Any model name supporting OpenAI API |
+| `approvalMode`      | string  | `suggest`  | AI assistant's permission mode | `suggest` (suggestions only)<br>`auto-edit` (automatic edits)<br>`full-auto` (fully automatic) |
+| `fullAutoErrorMode` | string  | `ask-user` | Error handling in full-auto mode | `ask-user` (prompt for user input)<br>`ignore-and-continue` (ignore and proceed) |
+| `notify`            | boolean | `true`     | Enable desktop notifications | `true`/`false` |
+| `maxContextLength`  | number  | _none_     | Override maximum context length (tokens) | Any positive number |
 yarn global add @openai/codex
 # or
 bun install -g @openai/codex

--- a/codex-cli/src/components/chat/terminal-chat.tsx
+++ b/codex-cli/src/components/chat/terminal-chat.tsx
@@ -490,6 +490,7 @@ export default function TerminalChat({
               PWD,
               model,
               provider,
+              maxContextLength: config.maxContextLength,
               approvalPolicy,
               colorsByPolicy,
               agent,

--- a/codex-cli/src/components/chat/terminal-header.tsx
+++ b/codex-cli/src/components/chat/terminal-header.tsx
@@ -10,6 +10,8 @@ export interface TerminalHeaderProps {
   PWD: string;
   model: string;
   provider?: string;
+  /** Optional override for the maximum context length */
+  maxContextLength?: number;
   approvalPolicy: string;
   colorsByPolicy: Record<string, string | undefined>;
   agent?: AgentLoop;
@@ -24,6 +26,7 @@ const TerminalHeader: React.FC<TerminalHeaderProps> = ({
   model,
   provider = "openai",
   approvalPolicy,
+  maxContextLength,
   colorsByPolicy,
   agent,
   initialImagePaths,
@@ -34,8 +37,9 @@ const TerminalHeader: React.FC<TerminalHeaderProps> = ({
       {terminalRows < 10 ? (
         // Compact header for small terminal windows
         <Text>
-          ● Codex v{version} - {PWD} - {model} ({provider}) -{" "}
-          <Text color={colorsByPolicy[approvalPolicy]}>{approvalPolicy}</Text>
+          ● Codex v{version} - {PWD} - {model} ({provider})
+          {typeof maxContextLength === "number" ? ` [ctx ${maxContextLength}]` : ""}
+          - <Text color={colorsByPolicy[approvalPolicy]}>{approvalPolicy}</Text>
           {flexModeEnabled ? " - flex-mode" : ""}
         </Text>
       ) : (
@@ -71,6 +75,12 @@ const TerminalHeader: React.FC<TerminalHeaderProps> = ({
               <Text color="blueBright">↳</Text> provider:{" "}
               <Text bold>{provider}</Text>
             </Text>
+            {typeof maxContextLength === "number" && (
+              <Text dimColor>
+                <Text color="blueBright">↳</Text> context:{" "}
+                <Text bold>{maxContextLength}</Text>
+              </Text>
+            )}
             <Text dimColor>
               <Text color="blueBright">↳</Text> approval:{" "}
               <Text bold color={colorsByPolicy[approvalPolicy]}>

--- a/codex-cli/src/utils/agent/sandbox/landlock.ts
+++ b/codex-cli/src/utils/agent/sandbox/landlock.ts
@@ -3,12 +3,12 @@ import type { AppConfig } from "../../config.js";
 import type { SpawnOptions } from "child_process";
 
 import { exec } from "./raw-exec.js";
+import { CODEX_UNSAFE_ALLOW_NO_SANDBOX } from "../../config.js";
 import { execFile } from "child_process";
 import fs from "fs";
 import path from "path";
 import { log } from "src/utils/logger/log.js";
 import { fileURLToPath } from "url";
-import { CODEX_UNSAFE_ALLOW_NO_SANDBOX } from "../../config.js";
 
 /**
  * Runs Landlock with the following permissions:

--- a/codex-cli/src/utils/config.ts
+++ b/codex-cli/src/utils/config.ts
@@ -170,6 +170,8 @@ export type StoredConfig = {
    * terminal output.
    */
   fileOpener?: FileOpenerScheme;
+  /** Override the maximum context length used for all models */
+  max_context_length?: number;
 };
 
 // Minimal config written on first run.  An *empty* model string ensures that
@@ -215,6 +217,8 @@ export type AppConfig = {
     };
   };
   fileOpener?: FileOpenerScheme;
+  /** Optional override for the maximum context length */
+  maxContextLength?: number;
 };
 
 // Formatting (quiet mode-only).
@@ -439,6 +443,7 @@ export const loadConfig = (
     disableResponseStorage: storedConfig.disableResponseStorage === true,
     reasoningEffort: storedConfig.reasoningEffort,
     fileOpener: storedConfig.fileOpener,
+    maxContextLength: storedConfig.max_context_length,
   };
 
   // -----------------------------------------------------------------------
@@ -560,6 +565,7 @@ export const saveConfig = (
     disableResponseStorage: config.disableResponseStorage,
     flexMode: config.flexMode,
     reasoningEffort: config.reasoningEffort,
+    max_context_length: config.maxContextLength,
   };
 
   // Add history settings if they exist

--- a/codex-cli/src/utils/model-utils.ts
+++ b/codex-cli/src/utils/model-utils.ts
@@ -1,7 +1,7 @@
 import type { ResponseItem } from "openai/resources/responses/responses.mjs";
 
 import { approximateTokensUsed } from "./approximate-tokens-used.js";
-import { getApiKey } from "./config.js";
+import { getApiKey, loadConfig } from "./config.js";
 import { type SupportedModelId, openAiModelInfo } from "./model-info.js";
 import { createOpenAIClient } from "./openai-client.js";
 
@@ -88,6 +88,10 @@ export async function isModelSupportedForResponses(
 
 /** Returns the maximum context length (in tokens) for a given model. */
 export function maxTokensForModel(model: string): number {
+  const override = loadConfig().maxContextLength;
+  if (typeof override === "number" && override > 0) {
+    return override;
+  }
   if (model in openAiModelInfo) {
     return openAiModelInfo[model as SupportedModelId].maxContextLength;
   }

--- a/codex-cli/tests/config.test.tsx
+++ b/codex-cli/tests/config.test.tsx
@@ -361,3 +361,40 @@ test("loads and saves custom shell config", () => {
   expect(reloadedConfig.tools?.shell?.maxBytes).toBe(updatedMaxBytes);
   expect(reloadedConfig.tools?.shell?.maxLines).toBe(updatedMaxLines);
 });
+
+test("loads and saves max_context_length", () => {
+  const initialMax = 12345;
+
+  memfs[testConfigPath] = JSON.stringify(
+    {
+      model: "mymodel",
+      max_context_length: initialMax,
+    },
+    null,
+    2,
+  );
+  memfs[testInstructionsPath] = "test instructions";
+
+  const loaded = loadConfig(testConfigPath, testInstructionsPath, {
+    disableProjectDoc: true,
+  });
+
+  expect(loaded.maxContextLength).toBe(initialMax);
+
+  const updatedMax = 54321;
+  saveConfig(
+    { ...loaded, maxContextLength: updatedMax },
+    testConfigPath,
+    testInstructionsPath,
+  );
+
+  expect(memfs[testConfigPath]).toContain(
+    `"max_context_length": ${updatedMax}`,
+  );
+
+  const reloaded = loadConfig(testConfigPath, testInstructionsPath, {
+    disableProjectDoc: true,
+  });
+
+  expect(reloaded.maxContextLength).toBe(updatedMax);
+});

--- a/codex-cli/tests/model-utils-config-override.test.ts
+++ b/codex-cli/tests/model-utils-config-override.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+
+afterEach(() => {
+  vi.resetModules();
+});
+
+describe("maxTokensForModel override via config", () => {
+  it("uses max_context_length from config when present", async () => {
+    vi.doMock("../src/utils/config.js", () => ({
+      loadConfig: () => ({ maxContextLength: 9999 }),
+    }));
+
+    const { maxTokensForModel } = await import("../src/utils/model-utils.js");
+    expect(maxTokensForModel("gpt-4o")).toBe(9999);
+  });
+
+  it("falls back to defaults when override absent", async () => {
+    vi.doMock("../src/utils/config.js", () => ({
+      loadConfig: () => ({ }),
+    }));
+
+    const { maxTokensForModel } = await import("../src/utils/model-utils.js");
+    expect(maxTokensForModel("some-model-32k")).toBe(32000);
+  });
+});


### PR DESCRIPTION
## Summary
- allow `max_context_length` in `config.json`
- return this value from `loadConfig`
- use the override in `maxTokensForModel`
- fix ESLint ordering in landlock util
- test config saving/loading of `max_context_length`
- test that `maxTokensForModel` respects the config override

## Testing
- `pnpm exec vitest run codex-cli/tests/model-utils-config-override.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_6855f88fc528832f894e7aa1d5cb7783