### PR TITLE
Implement conversation summary backlog

### DIFF
--- a/codex-cli/src/utils/io-log.ts
+++ b/codex-cli/src/utils/io-log.ts
@@ -4,7 +4,9 @@ import { appendFileSync } from "fs";
 
 function log(direction: string, data: unknown): void {
   const path = process.env[IO_LOG_ENV_VAR];
-  if (!path) return;
+  if (!path) {
+    return;
+  }
   try {
     const line = JSON.stringify({ direction, data }) + "\n";
     appendFileSync(path, line);

--- a/codex-cli/src/utils/prompt-builder.ts
+++ b/codex-cli/src/utils/prompt-builder.ts
@@ -1,0 +1,103 @@
+import type { AppConfig } from "./config.js";
+import type { OpenAI } from "openai";
+import type { ResponseItem } from "openai/resources/responses/responses";
+
+import { generateCompactSummary } from "./compact-summary.js";
+import { countPromptTokens } from "./token-metering.js";
+
+interface TextPart {
+  type?: string;
+  text?: string;
+}
+
+export interface PromptBuilderOptions {
+  maxTokens?: number;
+  keepMessages?: number;
+  maxPatchLines?: number;
+  model?: string;
+  flexMode?: boolean;
+  config?: AppConfig;
+}
+
+export class PromptBuilder {
+  private maxTokens: number;
+  private keepMessages: number;
+  private summaryBacklog: Array<string> = [];
+  private model: string;
+  private flexMode: boolean;
+  private config?: AppConfig;
+  private history: Array<ResponseItem> = [];
+
+  constructor(opts: PromptBuilderOptions = {}) {
+    this.maxTokens = opts.maxTokens ?? 6000;
+    this.keepMessages = opts.keepMessages ?? 6;
+    this.model = opts.model ?? "gpt-4.1";
+    this.flexMode = Boolean(opts.flexMode);
+    this.config = opts.config;
+  }
+
+  push(item: ResponseItem): void {
+    this.history.push(item);
+  }
+
+
+  private count(messages: Array<ResponseItem>): number {
+    return countPromptTokens(
+      messages.map((m) => {
+        if (m.type === "message" && typeof (m as { role?: string }).role === "string") {
+          const role = (m as { role: string }).role;
+          const content = Array.isArray(m.content)
+            ? (m.content as Array<TextPart>).map((p) => p.text || "").join("")
+            : typeof m.content === "string"
+              ? m.content
+              : "";
+          return { role, content };
+        }
+        return { role: "system", content: "" };
+      }) as unknown as Array<OpenAI.Chat.Completions.ChatCompletionMessageParam>,
+    );
+  }
+
+  private async summarizeOld(items: Array<ResponseItem>): Promise<void> {
+    if (!items.length) {
+      return;
+    }
+    const summary = await generateCompactSummary(
+      items,
+      this.model,
+      this.flexMode,
+      this.config as AppConfig,
+    );
+    this.summaryBacklog.push(summary);
+  }
+
+  async build(): Promise<Array<ResponseItem>> {
+    const keep = this.history.slice(-this.keepMessages);
+    if (this.history.length > this.keepMessages) {
+      const old = this.history.slice(0, -this.keepMessages);
+      await this.summarizeOld(old);
+    }
+    const result: Array<ResponseItem> = [];
+    if (this.summaryBacklog.length) {
+      result.push({
+        type: "message",
+        role: "system",
+        content: [{ type: "input_text", text: this.summaryBacklog.join(" ") }],
+      } as unknown as ResponseItem);
+    }
+    result.push(...keep);
+
+    while (this.count(result) > this.maxTokens && result.length > 1) {
+      const removed = result.splice(1, 1)[0] as ResponseItem;
+      // eslint-disable-next-line no-await-in-loop -- summarization is sequential
+      await this.summarizeOld([removed]);
+      if (result[0]) {
+        (result[0] as { content: Array<TextPart> }).content = [
+          { type: "input_text", text: this.summaryBacklog.join(" ") },
+        ];
+      }
+    }
+    return result;
+  }
+}
+

--- a/codex-cli/src/utils/responses.ts
+++ b/codex-cli/src/utils/responses.ts
@@ -1,14 +1,15 @@
 import type { OpenAI } from "openai";
+import type {
+  ResponseCreateParams,
+  Response,
+} from "openai/resources/responses/responses";
+
 import { logInput, logOutput } from "./io-log.js";
 import {
   recordTokenUsage,
   countPromptTokens,
   countTextTokens,
 } from "./token-metering.js";
-import type {
-  ResponseCreateParams,
-  Response,
-} from "openai/resources/responses/responses";
 
 // Define interfaces based on OpenAI API documentation
 type ResponseCreateInput = ResponseCreateParams;

--- a/codex-cli/src/utils/token-metering.ts
+++ b/codex-cli/src/utils/token-metering.ts
@@ -1,7 +1,8 @@
-export const TOKEN_LOG_ENV_VAR = "CODEX_TOKEN_LOG";
+import type { OpenAI } from "openai";
 
 import { appendFileSync } from "fs";
-import type { OpenAI } from "openai";
+
+export const TOKEN_LOG_ENV_VAR = "CODEX_TOKEN_LOG";
 
 export function recordTokenUsage(
   model: string,
@@ -9,7 +10,9 @@ export function recordTokenUsage(
   completionTokens: number,
 ): void {
   const path = process.env[TOKEN_LOG_ENV_VAR];
-  if (!path) return;
+  if (!path) {
+    return;
+  }
   try {
     appendFileSync(path, `${model},${promptTokens},${completionTokens}\n`);
   } catch {

--- a/codex-cli/tests/token-metering.test.ts
+++ b/codex-cli/tests/token-metering.test.ts
@@ -11,7 +11,7 @@ import type { OpenAI } from "openai";
 test("recordTokenUsage appends to file", () => {
   const dir = mkdtempSync(join(tmpdir(), "codex-test-"));
   const file = join(dir, "log.csv");
-  process.env.CODEX_TOKEN_LOG = file;
+  process.env["CODEX_TOKEN_LOG"] = file;
   recordTokenUsage("model", 1, 2);
   const content = readFileSync(file, "utf8").trim();
   expect(content).toBe("model,1,2");

--- a/codex-rs/core/src/lib.rs
+++ b/codex-rs/core/src/lib.rs
@@ -36,6 +36,7 @@ pub mod protocol;
 mod rollout;
 mod safety;
 mod user_notification;
+pub mod prompt_assembler;
 pub mod util;
 
 pub use client_common::model_supports_reasoning_summaries;

--- a/codex-rs/core/src/prompt_assembler.rs
+++ b/codex-rs/core/src/prompt_assembler.rs
@@ -1,0 +1,95 @@
+use crate::models::{ResponseItem, ContentItem};
+use crate::token_metering::count_text_tokens;
+
+pub struct PromptAssembler {
+    max_tokens: usize,
+    keep_messages: usize,
+    summary: String,
+    history: Vec<ResponseItem>,
+}
+
+impl PromptAssembler {
+    pub fn new(max_tokens: usize, keep_messages: usize) -> Self {
+        Self { max_tokens, keep_messages, summary: String::new(), history: Vec::new() }
+    }
+
+    pub fn push(&mut self, item: ResponseItem) {
+        self.history.push(item);
+    }
+
+    fn summarize_item(item: &ResponseItem) -> String {
+        match item {
+            ResponseItem::Message { role, content } => {
+                let mut text = String::new();
+                for c in content {
+                    match c {
+                        ContentItem::InputText { text: t } | ContentItem::OutputText { text: t } => {
+                            text.push_str(t);
+                        }
+                        _ => {}
+                    }
+                }
+                let text = text.replace('\n', " ");
+                let snippet = if text.len() > 40 { format!("{}…", &text[..40]) } else { text };
+                format!("{}: {}", role, snippet)
+            }
+            _ => String::new(),
+        }
+    }
+
+    fn count_tokens(&self, messages: &[ResponseItem]) -> usize {
+        let mut count = 0;
+        for m in messages {
+            if let ResponseItem::Message { content, .. } = m {
+                let mut text = String::new();
+                for c in content {
+                    match c {
+                        ContentItem::InputText { text: t } | ContentItem::OutputText { text: t } => {
+                            text.push_str(t);
+                        }
+                        _ => {}
+                    }
+                }
+                count += count_text_tokens("gpt-4", &text).unwrap_or(0);
+            }
+        }
+        count
+    }
+
+    pub fn assemble(&mut self) -> Vec<ResponseItem> {
+        let mut keep: Vec<ResponseItem> = self.history.iter().cloned().rev().take(self.keep_messages).collect();
+        keep.reverse();
+        if self.history.len() > self.keep_messages {
+            for item in &self.history[0..self.history.len() - self.keep_messages] {
+                let s = Self::summarize_item(item);
+                if !s.is_empty() {
+                    self.summary.push_str(&s);
+                    self.summary.push(' ');
+                }
+            }
+        }
+        let mut result = Vec::new();
+        if !self.summary.trim().is_empty() {
+            result.push(ResponseItem::Message {
+                role: "system".to_string(),
+                content: vec![ContentItem::InputText { text: self.summary.trim().to_string() }],
+            });
+        }
+        result.extend(keep);
+
+        while self.count_tokens(&result) > self.max_tokens && result.len() > 1 {
+            let removed = result.remove(1);
+            let s = Self::summarize_item(&removed);
+            if !s.is_empty() {
+                self.summary.push_str(&s);
+                self.summary.push(' ');
+                result[0] = ResponseItem::Message {
+                    role: "system".to_string(),
+                    content: vec![ContentItem::InputText { text: self.summary.trim().to_string() }],
+                };
+            }
+        }
+        result
+    }
+}
+


### PR DESCRIPTION
## Summary
- introduce backlog-based PromptBuilder that calls `generateCompactSummary`
- keep a running summary when trimming old messages

## Testing
- `pnpm run lint` in codex-cli
- `pnpm run typecheck` in codex-cli
- `CODEX_SANDBOX_NETWORK_DISABLED=1 cargo test --manifest-path codex-rs/core/Cargo.toml`

------
https://chatgpt.com/codex/tasks/task_e_68586db6ca10832fa1c25a1abb401f1a