### PR TITLE
Add last_response tool

### DIFF
--- a/codex-cli/src/utils/agent/agent-loop.ts
+++ b/codex-cli/src/utils/agent/agent-loop.ts
@@ -126,6 +126,14 @@ const localShellTool: Tool = {
   type: "local_shell",
 };
 
+const lastResponseTool: FunctionTool = {
+  type: "function",
+  name: "last_response",
+  description: "Indicates the model has completed its task and no further turns are required.",
+  strict: false,
+  parameters: { type: "object", properties: {}, additionalProperties: false },
+};
+
 export class AgentLoop {
   private model: string;
   private provider: string;
@@ -185,6 +193,8 @@ export class AgentLoop {
    *    400 | No tool output found for function call …
    *  error from OpenAI. */
   private pendingAborts: Set<string> = new Set();
+  /** When set the current run will end after processing the present turn. */
+  private stopAfterCurrentTurn = false;
   /** Set to true by `terminate()` – prevents any further use of the instance. */
   private terminated = false;
   /** Master abort controller – fires when terminate() is invoked. */
@@ -465,6 +475,11 @@ export class AgentLoop {
     // used to tell model to stop if needed
     const additionalItems: Array<ResponseInputItem> = [];
 
+    if (name === "last_response") {
+      this.stopAfterCurrentTurn = true;
+      return [];
+    }
+
     // TODO: allow arbitrary function calls (beyond shell/container.exec)
     if (name === "container.exec" || name === "shell") {
       const {
@@ -601,6 +616,7 @@ export class AgentLoop {
 
       // Reset cancellation flag and stream for a fresh run.
       this.canceled = false;
+      this.stopAfterCurrentTurn = false;
       this.currentStream = null;
 
       // Create a fresh AbortController for this run so that tool calls from a
@@ -661,9 +677,9 @@ export class AgentLoop {
       // `disableResponseStorage === true`.
       let transcriptPrefixLen = 0;
 
-      let tools: Array<Tool> = [shellFunctionTool];
+      let tools: Array<Tool> = [shellFunctionTool, lastResponseTool];
       if (this.model.startsWith("codex")) {
-        tools = [localShellTool];
+        tools = [localShellTool, lastResponseTool];
       }
 
       const stripInternalFields = (
@@ -1179,7 +1195,7 @@ export class AgentLoop {
             // the next turn to an empty array to prevent an infinite loop.
             // And don't update the turn input too early otherwise we won't have the
             // current turn inputs available for retries.
-            turnInput = newTurnInput;
+            turnInput = this.stopAfterCurrentTurn ? [] : newTurnInput;
 
             // Stream finished successfully – leave the retry loop.
             break;

--- a/codex-cli/tests/agent-last-response.test.ts
+++ b/codex-cli/tests/agent-last-response.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi } from "vitest";
+
+class FakeStream {
+  public controller = { abort: vi.fn() };
+  async *[Symbol.asyncIterator]() {
+    yield {
+      type: "response.output_item.done",
+      item: {
+        type: "function_call",
+        id: "call_last",
+        name: "last_response",
+        arguments: "{}",
+      },
+    } as any;
+    yield {
+      type: "response.completed",
+      response: {
+        id: "resp_last",
+        status: "completed",
+        output: [
+          {
+            type: "function_call",
+            id: "call_last",
+            name: "last_response",
+            arguments: "{}",
+          },
+        ],
+      },
+    } as any;
+  }
+}
+
+let callCount = 0;
+vi.mock("openai", () => {
+  class FakeOpenAI {
+    public responses = {
+      create: async () => {
+        callCount += 1;
+        if (callCount > 1) {
+          throw new Error("unexpected extra call");
+        }
+        return new FakeStream();
+      },
+    };
+  }
+  class APIConnectionTimeoutError extends Error {}
+  return { __esModule: true, default: FakeOpenAI, APIConnectionTimeoutError, _test: { getCallCount: () => callCount } };
+});
+
+vi.mock("../src/approvals.js", () => ({
+  __esModule: true,
+  alwaysApprovedCommands: new Set<string>(),
+  canAutoApprove: () => ({ type: "auto-approve", runInSandbox: false }) as any,
+  isSafeCommand: () => null,
+}));
+
+vi.mock("../src/format-command.js", () => ({
+  __esModule: true,
+  formatCommandForDisplay: (cmd: Array<string>) => cmd.join(" "),
+}));
+
+vi.mock("../src/utils/agent/log.js", () => ({
+  __esModule: true,
+  log: () => {},
+  isLoggingEnabled: () => false,
+}));
+
+import { AgentLoop } from "../src/utils/agent/agent-loop.js";
+
+describe("last_response tool", () => {
+  it("stops further iterations when invoked", async () => {
+    const { _test } = (await import("openai")) as any;
+
+    const agent = new AgentLoop({
+      model: "any",
+      instructions: "",
+      config: { model: "any", instructions: "", notify: false },
+      approvalPolicy: { mode: "auto" } as any,
+      additionalWritableRoots: [],
+      onItem: () => {},
+      onLoading: () => {},
+      getCommandConfirmation: async () => ({ review: "yes" }) as any,
+      onLastResponseId: () => {},
+    });
+
+    const userMsg = [
+      {
+        type: "message",
+        role: "user",
+        content: [{ type: "input_text", text: "hi" }],
+      },
+    ];
+
+    await agent.run(userMsg as any);
+
+    await new Promise((r) => setTimeout(r, 20));
+
+    expect(_test.getCallCount()).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- introduce `last_response` tool for the agent loop
- stop iterations when the new tool is used
- test the new behaviour

## Testing
- `pnpm --filter @openai/codex exec vitest run codex-cli/tests/agent-last-response.test.ts` *(fails: Command "vitest" not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c9f301240832fb58bf73ec145df71