### PR TITLE
Add exit flag to CLI

### DIFF
--- a/codex-cli/src/app.tsx
+++ b/codex-cli/src/app.tsx
@@ -25,6 +25,7 @@ type Props = {
   approvalPolicy: ApprovalPolicy;
   additionalWritableRoots: ReadonlyArray<string>;
   fullStdout: boolean;
+  exitAfterRun?: boolean;
 };
 
 export default function App({
@@ -35,6 +36,7 @@ export default function App({
   approvalPolicy,
   additionalWritableRoots,
   fullStdout,
+  exitAfterRun,
 }: Props): JSX.Element {
   const app = useApp();
   const [accepted, setAccepted] = useState(() => false);
@@ -103,6 +105,7 @@ export default function App({
       approvalPolicy={approvalPolicy}
       additionalWritableRoots={additionalWritableRoots}
       fullStdout={fullStdout}
+      exitAfterRun={exitAfterRun}
     />
   );
 }

--- a/codex-cli/src/cli.tsx
+++ b/codex-cli/src/cli.tsx
@@ -92,6 +92,7 @@ const cli = meow(
     --no-project-doc           Do not automatically include the repository's 'AGENTS.md'
     --project-doc <file>       Include an additional markdown file at <file> as context
     --full-stdout              Do not truncate stdout/stderr from command outputs
+    --exit                     Exit after the model finishes responding
     --notify                   Enable desktop notifications for responses
 
     --disable-response-storage Disable server‑side response storage (sends the
@@ -186,6 +187,10 @@ const cli = meow(
         description:
           "Disable truncation of command stdout/stderr messages (show everything)",
         aliases: ["no-truncate"],
+      },
+      exit: {
+        type: "boolean",
+        description: "Exit after the initial run has completed",
       },
       reasoning: {
         type: "string",
@@ -581,6 +586,7 @@ const instance = render(
     approvalPolicy={approvalPolicy}
     additionalWritableRoots={additionalWritableRoots}
     fullStdout={Boolean(cli.flags.fullStdout)}
+    exitAfterRun={Boolean(cli.flags.exit)}
   />,
   {
     patchConsole: process.env["DEBUG"] ? false : true,

--- a/codex-cli/src/components/chat/terminal-chat.tsx
+++ b/codex-cli/src/components/chat/terminal-chat.tsx
@@ -37,7 +37,8 @@ import ModelOverlay from "../model-overlay.js";
 import SessionsOverlay from "../sessions-overlay.js";
 import chalk from "chalk";
 import fs from "fs/promises";
-import { Box, Text } from "ink";
+import { Box, Text, useApp } from "ink";
+import { onExit } from "../../utils/terminal.js";
 import { spawn } from "node:child_process";
 import React, { useEffect, useMemo, useRef, useState } from "react";
 import { inspect } from "util";
@@ -58,6 +59,7 @@ type Props = {
   approvalPolicy: ApprovalPolicy;
   additionalWritableRoots: ReadonlyArray<string>;
   fullStdout: boolean;
+  exitAfterRun?: boolean;
 };
 
 const colorsByPolicy: Record<ApprovalPolicy, ColorName | undefined> = {
@@ -143,8 +145,10 @@ export default function TerminalChat({
   approvalPolicy: initialApprovalPolicy,
   additionalWritableRoots,
   fullStdout,
+  exitAfterRun,
 }: Props): React.ReactElement {
   const notify = Boolean(config.notify);
+  const app = useApp();
   const [model, setModel] = useState<string>(config.model);
   const [provider, setProvider] = useState<string>(config.provider || "openai");
   const [lastResponseId, setLastResponseId] = useState<string | null>(null);
@@ -576,7 +580,16 @@ export default function TerminalChat({
               ]);
             }}
             submitInput={(inputs) => {
-              agent.run(inputs, lastResponseId || "");
+              agent.run(inputs, lastResponseId || "").then(() => {
+                if (exitAfterRun) {
+                  // Wait one frame so Ink can flush the final output
+                  setTimeout(() => {
+                    app.exit();
+                    onExit();
+                    process.exit(0);
+                  }, 60);
+                }
+              });
               return {};
             }}
             items={items}


### PR DESCRIPTION
## Summary
- add `--exit` flag to `codex` CLI
- plumb the flag through the UI to exit once the agent loop finishes
- ensure final response renders before exiting

## Testing
- `pnpm test` *(fails: vitest not found)*
- `pnpm lint` *(fails: eslint config missing)*

------
https://chatgpt.com/codex/tasks/task_e_6860fd279098832f92cb04d6b0d4a488