### PR TITLE
Add continue tool

### DIFF
--- a/codex-cli/src/components/chat/terminal-chat-response-item.tsx
+++ b/codex-cli/src/components/chat/terminal-chat-response-item.tsx
@@ -177,6 +177,18 @@ function TerminalChatResponseToolCall({
   let workdir: string | undefined;
   let cmdReadableText: string | undefined;
   if (message.type === "function_call") {
+    const name: string | undefined =
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (message as any).function?.name ?? (message as any).name;
+    if (name === "continue") {
+      return (
+        <Box flexDirection="column" gap={1}>
+          <Text color="magentaBright" bold>
+            continue
+          </Text>
+        </Box>
+      );
+    }
     const details = parseToolCall(message);
     workdir = details?.workdir;
     cmdReadableText = details?.cmdReadableText;
@@ -208,6 +220,15 @@ function TerminalChatResponseToolCallOutput({
 }) {
   const { output, metadata } = parseToolCallOutput(message.output);
   const { exit_code, duration_seconds } = metadata;
+  if (output === "continue") {
+    return (
+      <Box flexDirection="column" gap={1}>
+        <Text color="magenta" bold>
+          continue
+        </Text>
+      </Box>
+    );
+  }
   const metadataInfo = useMemo(
     () =>
       [

--- a/codex-cli/src/utils/agent/agent-loop.ts
+++ b/codex-cli/src/utils/agent/agent-loop.ts
@@ -118,6 +118,14 @@ const localShellTool: Tool = {
   type: "local_shell",
 };
 
+const continueTool: FunctionTool = {
+  type: "function",
+  name: "continue",
+  description:
+    "Indicates that the model wants to continue planning or produce more output in the next response.",
+  parameters: { type: "object", properties: {}, additionalProperties: false },
+};
+
 export class AgentLoop {
   private model: string;
   private provider: string;
@@ -450,7 +458,9 @@ export class AgentLoop {
     const additionalItems: Array<ResponseInputItem> = [];
 
     // TODO: allow arbitrary function calls (beyond shell/container.exec)
-    if (name === "container.exec" || name === "shell") {
+    if (name === "continue") {
+      outputItem.output = "continue";
+    } else if (name === "container.exec" || name === "shell") {
       const {
         outputText,
         metadata,
@@ -637,9 +647,9 @@ export class AgentLoop {
       // `disableResponseStorage === true`.
       let transcriptPrefixLen = 0;
 
-      let tools: Array<Tool> = [shellFunctionTool];
+      let tools: Array<Tool> = [shellFunctionTool, continueTool];
       if (this.model.startsWith("codex")) {
-        tools = [localShellTool];
+        tools = [localShellTool, continueTool];
       }
 
       const stripInternalFields = (

--- a/codex-cli/src/utils/parsers.ts
+++ b/codex-cli/src/utils/parsers.ts
@@ -15,6 +15,9 @@ export function parseToolCallOutput(toolCallOutput: string): {
   output: string;
   metadata: ExecOutputMetadata;
 } {
+  if (toolCallOutput.trim() === "continue") {
+    return { output: "continue", metadata: { exit_code: 0, duration_seconds: 0 } };
+  }
   try {
     const { output, metadata } = JSON.parse(toolCallOutput);
     return {


### PR DESCRIPTION
## Summary
- support a `continue` tool to let models request more planning
- handle `continue` tool calls in UI and parser

## Testing
- `pnpm -r test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861bc27eb4c832fb2581ac6d56aea04