### PR TITLE
Add tool call logging

### DIFF
--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -1278,6 +1278,10 @@ async fn handle_container_exec_with_params(
         MaybeApplyPatchVerified::NotApplyPatch => (),
     }
 
+    // Log the command that will be executed so it shows up in the TUI log.
+    let command_str = params.command.join(" ");
+    info!("exec tool call: {command_str}");
+
     // safety checks
     let safety = {
         let state = sess.state.lock().unwrap();
@@ -1512,6 +1516,7 @@ async fn apply_patch(
     call_id: String,
     action: ApplyPatchAction,
 ) -> ResponseInputItem {
+    info!("apply_patch tool call");
     let writable_roots_snapshot = {
         let guard = sess.writable_roots.lock().unwrap();
         guard.clone()

--- a/codex-rs/core/src/mcp_tool_call.rs
+++ b/codex-rs/core/src/mcp_tool_call.rs
@@ -9,6 +9,7 @@ use crate::protocol::Event;
 use crate::protocol::EventMsg;
 use crate::protocol::McpToolCallBeginEvent;
 use crate::protocol::McpToolCallEndEvent;
+use tracing::info;
 
 /// Handles the specified tool call dispatches the appropriate
 /// `McpToolCallBegin` and `McpToolCallEnd` events to the `Session`.
@@ -47,6 +48,7 @@ pub(crate) async fn handle_mcp_tool_call(
         tool: tool_name.clone(),
         arguments: arguments_value.clone(),
     });
+    info!("MCP tool call: {server}.{tool_name}");
     notify_mcp_tool_call_event(sess, sub_id, tool_call_begin_event).await;
 
     // Perform the tool call.


### PR DESCRIPTION
## Summary
- log server and tool name when starting an MCP tool call
- log command being executed for container.exec
- log when an apply_patch call is performed

## Testing
- `cargo check`
- `cargo test --workspace --no-run`

------
https://chatgpt.com/codex/tasks/task_e_6861dc1e1434832fbf670988b6ff9391