### PR TITLE
Add continue tool support

### DIFF
--- a/codex-cli/src/components/chat/terminal-chat-response-item.tsx
+++ b/codex-cli/src/components/chat/terminal-chat-response-item.tsx
@@ -177,6 +177,16 @@ function TerminalChatResponseToolCall({
   let workdir: string | undefined;
   let cmdReadableText: string | undefined;
   if (message.type === "function_call") {
+    const name = (message as any).name ?? (message as any).function?.name;
+    if (name === "continue") {
+      return (
+        <Box flexDirection="column" gap={1}>
+          <Text color="magentaBright" bold>
+            continue
+          </Text>
+        </Box>
+      );
+    }
     const details = parseToolCall(message);
     workdir = details?.workdir;
     cmdReadableText = details?.cmdReadableText;


### PR DESCRIPTION
## Summary
- add `continue` tool definition for planning between turns
- handle `continue` in the function call processor
- register `continue` tool in available tools
- show `continue` in terminal output
- document `continue` usage in system instructions

## Testing
- `pnpm test` *(fails: vitest not found)*
- `cargo test` *(fails: 1 test failed)*

------
https://chatgpt.com/codex/tasks/task_e_68620a110ab0832fa89e8fa9157b44cb