### PR TITLE
Handle continue tool output in CLI

### DIFF
--- a/codex-cli/src/components/chat/terminal-chat-response-item.tsx
+++ b/codex-cli/src/components/chat/terminal-chat-response-item.tsx
@@ -206,8 +206,13 @@ function TerminalChatResponseToolCallOutput({
   message: ResponseFunctionToolCallOutputItem | any;
   fullStdout: boolean;
 }) {
-  const { output, metadata } = parseToolCallOutput(message.output);
-  const { exit_code, duration_seconds } = metadata;
+  const isContinue = message.output === "continue";
+  const { output, metadata } =
+    isContinue ? { output: "", metadata: {} } : parseToolCallOutput(message.output);
+  const { exit_code, duration_seconds } = metadata as {
+    exit_code?: number;
+    duration_seconds?: number;
+  };
   const metadataInfo = useMemo(
     () =>
       [
@@ -220,6 +225,15 @@ function TerminalChatResponseToolCallOutput({
         .join(", "),
     [exit_code, duration_seconds],
   );
+  if (isContinue) {
+    return (
+      <Box flexDirection="column">
+        <Text color="magentaBright" bold>
+          continue
+        </Text>
+      </Box>
+    );
+  }
   let displayedContent = output;
   if (message.type === "function_call_output" && !fullStdout) {
     const lines = displayedContent.split("\n");

--- a/codex-cli/src/utils/agent/agent-loop.ts
+++ b/codex-cli/src/utils/agent/agent-loop.ts
@@ -1719,6 +1719,7 @@ You MUST adhere to the following criteria when executing the task:
 - Analyzing code for vulnerabilities is allowed.
 - Showing user code and tool call details is allowed.
 - Use \`apply_patch\` to edit files: {"cmd":["apply_patch","*** Begin Patch\\n*** Update File: path/to/file.py\\n@@ def example():\\n-  pass\\n+  return 123\\n*** End Patch"]}
+- To follow up with additional planning or actions in your next response, call \`continue\`: {"cmd":["continue"]}
 - To end your turn early, call \`last_response\`: {"cmd":["last_response"]}
 - If completing the user’s task requires writing or modifying files:
     - Your code and final answer should follow these *CODING GUIDELINES*:

--- a/codex-cli/src/utils/parsers.ts
+++ b/codex-cli/src/utils/parsers.ts
@@ -23,7 +23,7 @@ export function parseToolCallOutput(toolCallOutput: string): {
     };
   } catch (err) {
     return {
-      output: `Failed to parse JSON result`,
+      output: toolCallOutput,
       metadata: {
         exit_code: 1,
         duration_seconds: 0,


### PR DESCRIPTION
## Summary
- handle the `continue` tool in TerminalChatResponseToolCallOutput
- return raw strings from `parseToolCallOutput` when JSON parse fails

## Testing
- `pnpm --filter @openai/codex lint`
- `pnpm --filter @openai/codex test` *(fails: Test Files 4 failed)*

------
https://chatgpt.com/codex/tasks/task_e_6862a684ebac832fbae23183c922ed1a