### PR TITLE
Add request workflow runner

### DIFF
--- a/codex-cli/src/cli.tsx
+++ b/codex-cli/src/cli.tsx
@@ -29,6 +29,7 @@ import App from "./app";
 import { runSinglePass } from "./cli-singlepass";
 import SessionsOverlay from "./components/sessions-overlay.js";
 import { AgentLoop } from "./utils/agent/agent-loop";
+import { runWorkflow, defaultWorkflow } from "./workflow.js";
 import { ReviewDecision } from "./utils/agent/review";
 import { AutoApprovalMode } from "./utils/auto-approval-mode";
 import { checkForUpdates } from "./utils/check-updates";
@@ -687,7 +688,7 @@ async function runQuietMode({
   });
 
   const inputItem = await createInputItem(prompt, imagePaths);
-  await agent.run([inputItem]);
+  await runWorkflow(defaultWorkflow, agent, [inputItem]);
 }
 
 const exit = () => {

--- a/codex-cli/src/components/chat/terminal-chat.tsx
+++ b/codex-cli/src/components/chat/terminal-chat.tsx
@@ -14,6 +14,7 @@ import { useConfirmation } from "../../hooks/use-confirmation.js";
 import { useTerminalSize } from "../../hooks/use-terminal-size.js";
 import { AgentLoop } from "../../utils/agent/agent-loop.js";
 import { ReviewDecision } from "../../utils/agent/review.js";
+import { runWorkflow, defaultWorkflow } from "../../workflow.js";
 import { generateCompactSummary } from "../../utils/compact-summary.js";
 import { saveConfig } from "../../utils/config.js";
 import { extractAppliedPatches as _extractAppliedPatches } from "../../utils/extract-applied-patches.js";
@@ -580,7 +581,12 @@ export default function TerminalChat({
               ]);
             }}
             submitInput={(inputs) => {
-              agent.run(inputs, lastResponseId || "").then(() => {
+              runWorkflow(
+                defaultWorkflow,
+                agent,
+                inputs,
+                lastResponseId || "",
+              ).then(() => {
                 if (exitAfterRun) {
                   // Wait one frame so Ink can flush the final output
                   setTimeout(() => {

--- a/codex-cli/src/workflow.ts
+++ b/codex-cli/src/workflow.ts
@@ -1,0 +1,31 @@
+export type WorkflowPhase = {
+  name: string;
+  run: (
+    agent: import("./utils/agent/agent-loop.js").AgentLoop,
+    input: Array<import("openai/resources/responses/responses.js").ResponseInputItem>,
+    previousResponseId: string,
+  ) => Promise<void>;
+};
+
+export type Workflow = ReadonlyArray<WorkflowPhase>;
+
+export async function runWorkflow(
+  workflow: Workflow,
+  agent: import("./utils/agent/agent-loop.js").AgentLoop,
+  input: Array<import("openai/resources/responses/responses.js").ResponseInputItem>,
+  previousResponseId = "",
+): Promise<void> {
+  let lastId = previousResponseId;
+  for (const phase of workflow) {
+    await phase.run(agent, input, lastId);
+  }
+}
+
+export const defaultWorkflow: Workflow = [
+  {
+    name: "default",
+    async run(agent, input, lastId) {
+      await agent.run(input, lastId);
+    },
+  },
+];

--- a/docs/workflow-plan.md
+++ b/docs/workflow-plan.md
@@ -1,0 +1,30 @@
+# Workflow design
+
+This document outlines how to introduce a configurable workflow into Codex CLI's request handling.
+
+## 1. Understand the current structure
+
+- **CLI entry**: `codex-cli/src/cli.tsx` sets up the `AgentLoop` and runs user requests.
+- **Agent loop**: `codex-cli/src/utils/agent/agent-loop.ts` submits prompts, streams model output and handles tool calls.
+- **Rust backend**: `codex-rs/core/src/codex.rs` implements `run_turn` and `handle_response_item` for executing shell commands and applying patches.
+- **Protocol types**: `codex-rs/core/src/protocol.rs` defines request and response structures.
+
+## 2. Map the workflow to existing flows
+
+Requests originate in the CLI. `AgentLoop.run` sends input to the backend via `Session::run_turn`. The backend streams events and handles function calls. A workflow would orchestrate these phases: analysis, command execution and patch application.
+
+## 3. Plan for a workflow module
+
+1. **Define phases**
+   - Create a new module (e.g. `codex-cli/src/workflow.ts`) describing ordered phases like `analyze`, `execute`, `generate_patches`.
+   - Each phase specifies a handler that can issue prompts, wait for approvals or run commands.
+2. **Integrate with AgentLoop**
+   - Pass the workflow definition when creating an `AgentLoop` instance.
+   - `AgentLoop.run` iterates through the phases, delegating to the workflow module to determine what inputs to send next.
+3. **Session support**
+   - Extend `codex-rs/core/src/codex.rs` to accept workflow metadata (such as the current phase) when running a turn.
+   - Use the metadata to drive the backend logic if certain phases should behave differently.
+4. **Configuration**
+   - Expose a CLI flag or configuration file section to select predefined workflows or provide a custom sequence.
+
+This design keeps backward compatibility (no workflow means the existing behaviour) while allowing advanced orchestration of request handling.


### PR DESCRIPTION
## Summary
- create a `workflow` helper with default phase runner
- wire the workflow into quiet mode and chat UI

## Testing
- `pnpm test` *(fails: ENOENT because node_modules missing)*
- `pnpm run lint` *(fails: ESLint config missing due to no modules)*
- `pnpm run typecheck` *(fails: cannot find node types)*

------
https://chatgpt.com/codex/tasks/task_e_6862c0f870ac832f94f112cdfb3d1f71