### PR TITLE
Add apply_patch fallback for missing files

### DIFF
--- a/codex-cli/package.json
+++ b/codex-cli/package.json
@@ -62,6 +62,7 @@
     "@types/semver": "^7.7.0",
     "@types/shell-quote": "^1.7.5",
     "@types/which": "^3.0.4",
+    "@types/node": "^22.14.1",
     "@typescript-eslint/eslint-plugin": "^7.18.0",
     "@typescript-eslint/parser": "^7.18.0",
     "boxen": "^8.0.1",

--- a/codex-cli/src/cli.tsx
+++ b/codex-cli/src/cli.tsx
@@ -29,6 +29,7 @@ import App from "./app";
 import { runSinglePass } from "./cli-singlepass";
 import SessionsOverlay from "./components/sessions-overlay.js";
 import { AgentLoop } from "./utils/agent/agent-loop";
+import { runWorkflow, defaultWorkflow } from "./workflow.js";
 import { ReviewDecision } from "./utils/agent/review";
 import { AutoApprovalMode } from "./utils/auto-approval-mode";
 import { checkForUpdates } from "./utils/check-updates";
@@ -687,7 +688,7 @@ async function runQuietMode({
   });
 
   const inputItem = await createInputItem(prompt, imagePaths);
-  await agent.run([inputItem]);
+  await runWorkflow(defaultWorkflow, agent, [inputItem]);
 }
 
 const exit = () => {

--- a/codex-cli/src/components/chat/terminal-chat-response-item.tsx
+++ b/codex-cli/src/components/chat/terminal-chat-response-item.tsx
@@ -177,6 +177,7 @@ function TerminalChatResponseToolCall({
   let workdir: string | undefined;
   let cmdReadableText: string | undefined;
   if (message.type === "function_call") {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const name = (message as any).name ?? (message as any).function?.name;
     if (name === "continue") {
       return (

--- a/codex-cli/src/components/chat/terminal-chat.tsx
+++ b/codex-cli/src/components/chat/terminal-chat.tsx
@@ -14,6 +14,7 @@ import { useConfirmation } from "../../hooks/use-confirmation.js";
 import { useTerminalSize } from "../../hooks/use-terminal-size.js";
 import { AgentLoop } from "../../utils/agent/agent-loop.js";
 import { ReviewDecision } from "../../utils/agent/review.js";
+import { runWorkflow, defaultWorkflow } from "../../workflow.js";
 import { generateCompactSummary } from "../../utils/compact-summary.js";
 import { saveConfig } from "../../utils/config.js";
 import { extractAppliedPatches as _extractAppliedPatches } from "../../utils/extract-applied-patches.js";
@@ -580,7 +581,12 @@ export default function TerminalChat({
               ]);
             }}
             submitInput={(inputs) => {
-              agent.run(inputs, lastResponseId || "").then(() => {
+              runWorkflow(
+                defaultWorkflow,
+                agent,
+                inputs,
+                lastResponseId || "",
+              ).then(() => {
                 if (exitAfterRun) {
                   // Wait one frame so Ink can flush the final output
                   setTimeout(() => {

--- a/codex-cli/src/utils/agent/agent-loop.ts
+++ b/codex-cli/src/utils/agent/agent-loop.ts
@@ -21,7 +21,7 @@ import {
   AZURE_OPENAI_API_VERSION,
 } from "../config.js";
 import { log } from "../logger/log.js";
-import { parseToolCallArguments } from "../parsers.js";
+import { parseToolCallArguments, parseApplyPatchArguments } from "../parsers.js";
 import { getEnvironmentInfo } from "../platform-info.js";
 import { responsesCreateViaChatCompletions } from "../responses.js";
 import {
@@ -173,8 +173,6 @@ export class AgentLoop {
     analysis?: string;
     file_structure?: string;
   };
-  /** Tools advertised to the model for the current run. */
-  private availableTools: Array<Tool> = [];
 
   /**
    * A reference to the currently active stream returned from the OpenAI
@@ -598,11 +596,40 @@ export class AgentLoop {
       if (
         this.jsonResponse &&
         Array.isArray(args.cmd) &&
+        args.cmd[0] &&
         ["ls", "find"].includes(args.cmd[0])
       ) {
         this.jsonResponse.file_structure = outputText;
       }
 
+      if (additionalItemsFromExec) {
+        additionalItems.push(...additionalItemsFromExec);
+      }
+    } else if (name === "apply_patch") {
+      const args = parseApplyPatchArguments(rawArguments ?? "{}");
+      if (args == null) {
+        const invalid: ResponseInputItem.FunctionCallOutput = {
+          type: "function_call_output",
+          call_id: callId,
+          output: `invalid arguments: ${rawArguments}`,
+        };
+        return [invalid];
+      }
+      const execArgs = {
+        cmd: ["apply_patch", args.patch],
+        workdir: args.workdir,
+        timeoutInMillis: undefined,
+      };
+      const { outputText, metadata, additionalItems: additionalItemsFromExec } =
+        await handleExecCommand(
+          execArgs,
+          this.config,
+          this.approvalPolicy,
+          this.additionalWritableRoots,
+          this.getCommandConfirmation,
+          this.execAbortController?.signal,
+        );
+      outputItem.output = JSON.stringify({ output: outputText, metadata });
       if (additionalItemsFromExec) {
         additionalItems.push(...additionalItemsFromExec);
       }
@@ -817,7 +844,6 @@ export class AgentLoop {
       if (this.model.startsWith("codex")) {
         tools = [localShellTool, continueTool, lastResponseTool];
       }
-      this.availableTools = tools;
 
       const stripInternalFields = this.stripInternalFields.bind(this);
 
@@ -1658,6 +1684,86 @@ export class AgentLoop {
     }
   }
 
+  private parseTextToolCall(text: string): ResponseItem | null {
+    const trimmed = text.trim();
+    let obj: Record<string, unknown> | null = null;
+    try {
+      obj = JSON.parse(trimmed);
+    } catch {
+      const first = trimmed.indexOf("{");
+      const last = trimmed.lastIndexOf("}");
+      if (first !== -1 && last !== -1 && first < last) {
+        try {
+          obj = JSON.parse(trimmed.slice(first, last + 1));
+        } catch {
+          obj = null;
+        }
+      }
+    }
+    if (!obj) {
+      return null;
+    }
+    try {
+      if (obj && typeof obj === "object") {
+        if (obj["name"] === "apply_patch") {
+          const args = parseApplyPatchArguments(JSON.stringify((obj as Record<string, unknown>)["parameters"] ?? {}));
+          if (!args) {
+            return null;
+          }
+          return {
+            type: "local_shell_call" as const,
+            id: randomUUID(),
+            status: "completed",
+            call_id: randomUUID(),
+            action: {
+              type: "exec",
+              command: ["apply_patch", args.patch],
+              working_directory: args.workdir,
+              timeout_ms: undefined,
+            },
+          } as unknown as ResponseItem;
+        }
+        const args = parseToolCallArguments(JSON.stringify(obj));
+        if (!args) {
+          return null;
+        }
+        return {
+          type: "local_shell_call" as const,
+          id: randomUUID(),
+          status: "completed",
+          call_id: randomUUID(),
+          action: {
+            type: "exec",
+            command: args.cmd,
+            working_directory: args.workdir,
+            timeout_ms: args.timeoutInMillis,
+          },
+        } as unknown as ResponseItem;
+      }
+    } catch {
+      if (trimmed.includes('"name": "apply_patch"')) {
+        const startIdx = trimmed.indexOf('*** Begin Patch');
+        const endIdx = trimmed.indexOf('*** End Patch');
+        if (startIdx !== -1 && endIdx !== -1) {
+          const patch = trimmed.slice(startIdx, endIdx + '*** End Patch'.length);
+          return {
+            type: "local_shell_call" as const,
+            id: randomUUID(),
+            status: "completed",
+            call_id: randomUUID(),
+            action: {
+              type: "exec",
+              command: ["apply_patch", patch],
+              working_directory: undefined,
+              timeout_ms: undefined,
+            },
+          } as unknown as ResponseItem;
+        }
+      }
+    }
+    return null;
+  }
+
   // we need until we can depend on streaming events
   private async processEventsWithoutStreaming(
     output: Array<ResponseInputItem>,
@@ -1691,6 +1797,32 @@ export class AgentLoop {
         // eslint-disable-next-line no-await-in-loop
         const result = await this.handleLocalShellCall(item);
         turnInput.push(...result);
+      } else if (
+        item.type === "message" &&
+        (item as { role?: string }).role === "assistant"
+      ) {
+        const parts = (item as { content?: Array<{ type?: string; text?: string }> }).content;
+        if (
+          Array.isArray(parts) &&
+          parts.length === 1 &&
+          parts[0] &&
+          parts[0].type === "output_text"
+        ) {
+          const text = (parts[0].text || "").trim();
+          const parsed = this.parseTextToolCall(text);
+          if (parsed) {
+            if ((parsed as ResponseItem).type === "local_shell_call") {
+              // eslint-disable-next-line no-await-in-loop
+              const result = await this.handleLocalShellCall(parsed as ResponseItem);
+              turnInput.push(...result);
+            } else {
+              // eslint-disable-next-line no-await-in-loop
+              const result = await this.handleFunctionCall(parsed as ResponseItem);
+              turnInput.push(...result);
+            }
+            continue;
+          }
+        }
       }
       emitItem(item as ResponseItem);
     }

--- a/codex-cli/src/utils/agent/agent-loop.ts
+++ b/codex-cli/src/utils/agent/agent-loop.ts
@@ -1868,6 +1868,9 @@ You MUST adhere to the following criteria when executing the task:
 - Analyzing code for vulnerabilities is allowed.
 - Showing user code and tool call details is allowed.
 - Use \`apply_patch\` to edit files: {"cmd":["apply_patch","*** Begin Patch\\n*** Update File: path/to/file.py\\n@@ def example():\\n-  pass\\n+  return 123\\n*** End Patch"]}
+  The patch must begin with \`*** Begin Patch\` and end with \`*** End Patch\`. Use \`*** Update File:\` or \`*** Add File:\` lines for each file. Provide hunks with @@ context.
+  Example:
+  {"cmd":["apply_patch","*** Begin Patch\\n*** Update File: hello.py\\n@@\\n+print('Hello World')\\n*** End Patch"]}
 - To follow up with additional planning or actions in your next response, call \`continue\`: {"cmd":["continue"]}
 - To end your turn early, call \`last_response\`: {"cmd":["last_response"]}
 - If completing the user’s task requires writing or modifying files:

--- a/codex-cli/src/utils/agent/exec.ts
+++ b/codex-cli/src/utils/agent/exec.ts
@@ -94,6 +94,8 @@ export function execApplyPatch(
     .replace(/\*\*\* End Patch\nEOF('|")?/, "*** End Patch")
     .trim();
 
+  applyPatchInput = stripHunkHeaders(applyPatchInput);
+
   // If the patch tries to update a file that doesn't exist, convert it to an
   // add operation so the patch succeeds.
   applyPatchInput = adjustPatchForMissingFiles(applyPatchInput, workdir);
@@ -153,6 +155,13 @@ function adjustPatchForMissingFiles(patch: string, workdir?: string): string {
     }
   }
   return lines.join("\n");
+}
+
+function stripHunkHeaders(patch: string): string {
+  return patch
+    .split("\n")
+    .filter((line) => !line.trim().startsWith("@@"))
+    .join("\n");
 }
 
 export function getBaseCmd(cmd: Array<string>): string {

--- a/codex-cli/src/utils/responses.ts
+++ b/codex-cli/src/utils/responses.ts
@@ -210,11 +210,18 @@ function convertInputItemToMessage(
           .join("")
       : "";
     return { role: responseItem.role, content };
-  } else if (responseItem.type === "function_call_output") {
+  } else if (
+    responseItem.type === "function_call_output" ||
+    // local_shell_call_output has the same structure as function_call_output
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (responseItem as any).type === "local_shell_call_output"
+  ) {
     return {
       role: "tool",
-      tool_call_id: responseItem.call_id,
-      content: responseItem.output,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      tool_call_id: (responseItem as any).call_id,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      content: (responseItem as any).output,
     };
   }
   throw new Error(`Unsupported input item type: ${responseItem.type}`);

--- a/codex-cli/src/workflow.ts
+++ b/codex-cli/src/workflow.ts
@@ -1,0 +1,39 @@
+import type { AgentLoop } from "./utils/agent/agent-loop.js";
+import type { ResponseInputItem } from "openai/resources/responses/responses";
+
+export interface WorkflowPhase {
+  name: string;
+  run: (
+    agent: AgentLoop,
+    input: Array<ResponseInputItem>,
+    previousResponseId: string,
+  ) => Promise<void>;
+}
+
+export type Workflow = ReadonlyArray<WorkflowPhase>;
+
+export async function runWorkflow(
+  workflow: Workflow,
+  agent: AgentLoop,
+  input: Array<ResponseInputItem>,
+  previousResponseId = "",
+): Promise<void> {
+  const lastId = previousResponseId;
+  for (const phase of workflow) {
+    // eslint-disable-next-line no-await-in-loop
+    await phase.run(agent, input, lastId);
+  }
+}
+
+export const defaultWorkflow: Workflow = [
+  {
+    name: "default",
+    async run(
+      agent: AgentLoop,
+      input: Array<ResponseInputItem>,
+      lastId: string,
+    ): Promise<void> {
+      await agent.run(input, lastId);
+    },
+  },
+];

--- a/codex-cli/tests/agent-missing-tool-call-retry.test.ts
+++ b/codex-cli/tests/agent-missing-tool-call-retry.test.ts
@@ -51,7 +51,7 @@ vi.mock("../src/utils/agent/log.js", () => ({
   isLoggingEnabled: () => false,
 }));
 
-import { AgentLoop } from "../src/utils/agent/agent-loop.ts";
+import { AgentLoop } from "../src/utils/agent/agent-loop.js";
 
 describe("AgentLoop – retry when missing tool call", () => {
   it("retries the request if no tool call is returned", async () => {

--- a/codex-cli/tests/exec-apply-patch.test.ts
+++ b/codex-cli/tests/exec-apply-patch.test.ts
@@ -42,3 +42,26 @@ test("execApplyPatch creates missing directories when adding a file", () => {
   // Cleanup to keep tmpdir tidy.
   fs.rmSync(tmpDir, { recursive: true, force: true });
 });
+
+test("execApplyPatch handles hunk headers", () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "apply-patch-test-"));
+  const fileRel = "hello.txt";
+  const fileAbs = path.join(tmpDir, fileRel);
+
+  const patch =
+    "*** Begin Patch\n*** Update File: hello.txt\n@@ -0,0 +1 @@\n+hi\n*** End Patch";
+
+  const prev = process.cwd();
+  try {
+    process.chdir(tmpDir);
+    const result = execApplyPatch(patch);
+    expect(result.exitCode).toBe(0);
+  } finally {
+    process.chdir(prev);
+  }
+
+  const content = fs.readFileSync(fileAbs, "utf8");
+  expect(content).toBe("hi");
+
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});

--- a/codex-cli/tests/parse-apply-patch-arguments.test.ts
+++ b/codex-cli/tests/parse-apply-patch-arguments.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from "vitest";
+import { parseApplyPatchArguments } from "../src/utils/parsers.js";
+
+describe("parseApplyPatchArguments", () => {
+  it("handles patch field", () => {
+    const patch = "*** Begin Patch\n*** Add File: foo\n+hi\n*** End Patch";
+    const args = parseApplyPatchArguments(JSON.stringify({ patch }));
+    expect(args).toEqual({ patch, workdir: undefined });
+  });
+
+  it("handles cmd array with apply_patch", () => {
+    const patch = "*** Begin Patch\n*** Add File: foo\n+hi\n*** End Patch";
+    const args = parseApplyPatchArguments(JSON.stringify({
+      cmd: ["apply_patch", patch],
+      workdir: "/tmp",
+    }));
+    expect(args).toEqual({ patch, workdir: "/tmp" });
+  });
+
+  it("handles body fields", () => {
+    const patch = "*** Begin Patch\n*** Add File: foo\n+hi\n*** End Patch";
+    const args1 = parseApplyPatchArguments(JSON.stringify({ body: patch }));
+    expect(args1).toEqual({ patch, workdir: undefined });
+    const args2 = parseApplyPatchArguments(JSON.stringify({ "*body": patch }));
+    expect(args2).toEqual({ patch, workdir: undefined });
+  });
+});

--- a/codex-cli/tests/parse-text-tool-call.test.ts
+++ b/codex-cli/tests/parse-text-tool-call.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("openai", () => {
+  class FakeOpenAI {
+    public responses = {
+      create: () => ({
+        controller: { abort: vi.fn() },
+        async *[Symbol.asyncIterator]() {}
+      }),
+    };
+  }
+  class APIConnectionTimeoutError extends Error {}
+  return { __esModule: true, default: FakeOpenAI, APIConnectionTimeoutError };
+});
+
+vi.mock("../src/approvals.js", () => ({
+  __esModule: true,
+  alwaysApprovedCommands: new Set<string>(),
+  canAutoApprove: () => ({ type: "auto-approve", runInSandbox: false }) as any,
+  isSafeCommand: () => null,
+}));
+
+vi.mock("../src/format-command.js", () => ({
+  __esModule: true,
+  formatCommandForDisplay: (c: Array<string>) => c.join(" "),
+}));
+
+vi.mock("../src/utils/agent/log.js", () => ({
+  __esModule: true,
+  log: () => {},
+  isLoggingEnabled: () => false,
+}));
+
+import { AgentLoop } from "../src/utils/agent/agent-loop.js";
+
+function createAgent() {
+  return new AgentLoop({
+    model: "any",
+    instructions: "",
+    config: { model: "any", instructions: "", notify: false },
+    approvalPolicy: { mode: "auto" } as any,
+    additionalWritableRoots: [],
+    onItem: () => {},
+    onLoading: () => {},
+    getCommandConfirmation: async () => ({ review: "yes" }) as any,
+    onLastResponseId: () => {},
+  });
+}
+
+describe("parseTextToolCall", () => {
+  it("parses JSON tool call followed by explanation", () => {
+    const agent = createAgent();
+    const text = '{"cmd":["echo","hi"]}\nMore info';
+    const parsed = (agent as any).parseTextToolCall(text);
+    expect(parsed).toMatchObject({
+      type: "local_shell_call",
+      action: { command: ["echo", "hi"] },
+    });
+  });
+
+  it("parses apply_patch json format", () => {
+    const agent = createAgent();
+    const patch = "*** Begin Patch\n*** Update File: foo\n+hi\n*** End Patch";
+    const text = JSON.stringify({
+      name: "apply_patch",
+      parameters: { patch },
+    });
+    const parsed = (agent as any).parseTextToolCall(text);
+    expect(parsed).toMatchObject({
+      // Parsed as a local shell call
+      type: "local_shell_call",
+      action: { command: ["apply_patch", patch] },
+    });
+  });
+});

--- a/codex-cli/tests/workflow.test.ts
+++ b/codex-cli/tests/workflow.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import { runWorkflow, defaultWorkflow } from "../src/workflow.js";
+
+// Simple stub agent that records calls to run()
+class StubAgent {
+  public calls: Array<{ input: any; lastId: string }> = [];
+  async run(input: any, lastId: string) {
+    this.calls.push({ input, lastId });
+  }
+}
+
+describe("workflow", () => {
+  it("executes phases in order", async () => {
+    const order: Array<string> = [];
+    const phases = [
+      {
+        name: "first",
+        async run() {
+          order.push("first");
+        },
+      },
+      {
+        name: "second",
+        async run() {
+          order.push("second");
+        },
+      },
+    ];
+    await runWorkflow(phases, {} as any, [], "id1");
+    expect(order).toEqual(["first", "second"]);
+  });
+
+  it("defaultWorkflow runs agent", async () => {
+    const agent = new StubAgent();
+    const input = ["dummy"] as any;
+    await runWorkflow(defaultWorkflow, agent as any, input, "prev");
+    expect(agent.calls).toEqual([{ input, lastId: "prev" }]);
+  });
+});

--- a/docs/workflow-plan.md
+++ b/docs/workflow-plan.md
@@ -1,0 +1,30 @@
+# Workflow design
+
+This document outlines how to introduce a configurable workflow into Codex CLI's request handling.
+
+## 1. Understand the current structure
+
+- **CLI entry**: `codex-cli/src/cli.tsx` sets up the `AgentLoop` and runs user requests.
+- **Agent loop**: `codex-cli/src/utils/agent/agent-loop.ts` submits prompts, streams model output and handles tool calls.
+- **Rust backend**: `codex-rs/core/src/codex.rs` implements `run_turn` and `handle_response_item` for executing shell commands and applying patches.
+- **Protocol types**: `codex-rs/core/src/protocol.rs` defines request and response structures.
+
+## 2. Map the workflow to existing flows
+
+Requests originate in the CLI. `AgentLoop.run` sends input to the backend via `Session::run_turn`. The backend streams events and handles function calls. A workflow would orchestrate these phases: analysis, command execution and patch application.
+
+## 3. Plan for a workflow module
+
+1. **Define phases**
+   - Create a new module (e.g. `codex-cli/src/workflow.ts`) describing ordered phases like `analyze`, `execute`, `generate_patches`.
+   - Each phase specifies a handler that can issue prompts, wait for approvals or run commands.
+2. **Integrate with AgentLoop**
+   - Pass the workflow definition when creating an `AgentLoop` instance.
+   - `AgentLoop.run` iterates through the phases, delegating to the workflow module to determine what inputs to send next.
+3. **Session support**
+   - Extend `codex-rs/core/src/codex.rs` to accept workflow metadata (such as the current phase) when running a turn.
+   - Use the metadata to drive the backend logic if certain phases should behave differently.
+4. **Configuration**
+   - Expose a CLI flag or configuration file section to select predefined workflows or provide a custom sequence.
+
+This design keeps backward compatibility (no workflow means the existing behaviour) while allowing advanced orchestration of request handling.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,7 +74,7 @@ importers:
         version: 15.0.8
       marked-terminal:
         specifier: ^7.3.0
-        version: 7.3.0(patch_hash=536fe9685e91d559cf29a033191aa39da45729949e9d1c69989255091c8618fb)(marked@15.0.8)
+        version: 7.3.0(marked@15.0.8)
       meow:
         specifier: ^13.2.0
         version: 13.2.0
@@ -121,6 +121,9 @@ importers:
       '@types/marked-terminal':
         specifier: ^6.1.1
         version: 6.1.1
+      '@types/node':
+        specifier: ^22.14.1
+        version: 22.14.1
       '@types/react':
         specifier: ^18.0.32
         version: 18.3.20
@@ -4519,7 +4522,7 @@ snapshots:
 
   make-error@1.3.6: {}
 
-  marked-terminal@7.3.0(patch_hash=536fe9685e91d559cf29a033191aa39da45729949e9d1c69989255091c8618fb)(marked@15.0.8):
+  marked-terminal@7.3.0(marked@15.0.8):
     dependencies:
       ansi-escapes: 7.0.0
       ansi-regex: 6.1.0


### PR DESCRIPTION
## Summary
- add `@types/node` dev dependency
- parse `apply_patch` argument JSON formats and plain text tool calls
- execute `apply_patch` via `exec` with automatic file-create fallback
- add workflow helper for sequential phases
- update agent loop to parse JSON tool calls in text
- add unit tests for new parsers and workflow
- fix lint errors and typecheck
- handle malformed apply_patch JSON
- improve JSON tool call parsing
- fix tool call parsing

## Testing
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm test` *(fails: see logs)*

------
https://chatgpt.com/codex/tasks/task_e_6862c0f870ac832f94f112cdfb3d1f71