### PR TITLE
Fix apply_patch parsing for invalid JSON tool calls

### DIFF
--- a/codex-cli/src/utils/agent/agent-loop.ts
+++ b/codex-cli/src/utils/agent/agent-loop.ts
@@ -1701,6 +1701,25 @@ export class AgentLoop {
       }
     }
     if (!obj) {
+      if (trimmed.includes('"name": "apply_patch"')) {
+        const startIdx = trimmed.indexOf('*** Begin Patch');
+        const endIdx = trimmed.indexOf('*** End Patch');
+        if (startIdx !== -1 && endIdx !== -1) {
+          const patch = trimmed.slice(startIdx, endIdx + '*** End Patch'.length);
+          return {
+            type: "local_shell_call" as const,
+            id: randomUUID(),
+            status: "completed",
+            call_id: randomUUID(),
+            action: {
+              type: "exec",
+              command: ["apply_patch", patch],
+              working_directory: undefined,
+              timeout_ms: undefined,
+            },
+          } as unknown as ResponseItem;
+        }
+      }
       return null;
     }
     try {


### PR DESCRIPTION
## Summary
- handle malformed apply_patch tool calls in `parseTextToolCall`

## Testing
- `pnpm --filter @openai/codex run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869bd36c1f0832fbd62ef082f1ecf86