### PR TITLE
Handle apply_patch parse errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ You can install any of these versions: `npm install -g codex@version`
 
 - Add node version check (#1007)
 - Persist token after refresh (#1006)
+- Return apply_patch parse errors without executing the shell command (#PR)
 
 ## `0.1.2505171619`
 


### PR DESCRIPTION
## Summary
- return a function call output when apply_patch arguments can't be parsed
- test that parse errors return immediately
- document parse error fix

## Testing
- `cargo test -p codex-core --quiet`

------
https://chatgpt.com/codex/tasks/task_e_686ac047771c832f8dfd17832949ced5