### PR TITLE
Handle parse errors in shell calls

### DIFF
--- a/codex-cli/tests/parse-tool-call-arguments.test.ts
+++ b/codex-cli/tests/parse-tool-call-arguments.test.ts
@@ -1,0 +1,9 @@
+import { describe, it, expect } from "vitest";
+import { parseToolCallArguments } from "../src/utils/parsers.js";
+
+describe("parseToolCallArguments", () => {
+  it("returns error on invalid JSON", () => {
+    const result = parseToolCallArguments('{');
+    expect(result.ok).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- add structured return type for `parseToolCallArguments`
- surface shell argument parse errors in agent loop
- test invalid shell tool call parsing

## Testing
- `cargo test --manifest-path codex-rs/Cargo.toml --workspace --exclude codex-linux-sandbox` *(fails: Elapsed(()))*
- `pnpm -r test` *(fails: spawn ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_686ac78a9a04832fafca42472f09124c